### PR TITLE
Avoid reading save files in load-menu logic

### DIFF
--- a/GetDressed/Framework/LocalConfig.cs
+++ b/GetDressed/Framework/LocalConfig.cs
@@ -18,10 +18,6 @@ namespace GetDressed.Framework
         [JsonIgnore]
         public string SaveName { get; set; }
 
-        /// <summary>When the associated save was last updated.</summary>
-        [JsonIgnore]
-        public int SaveTime { get; set; }
-
         /****
         ** Settings
         ****/

--- a/GetDressed/GetDressed.csproj
+++ b/GetDressed/GetDressed.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>GetDressed</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -134,17 +135,11 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
-  <Target Name="AfterBuild">
-    <ItemGroup>
-      <ModFiles Include="$(TargetDir)\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(ModFiles)" DestinationFolder="$(GamePath)\Mods\$(TargetName)\%(RecursiveDir)" SkipUnchangedFiles="false" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.6.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/GetDressed/packages.config
+++ b/GetDressed/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.6.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Get Dressed reads the save files before customising the load menu, which causes many of the errors users get.

This pull request...
* changes the code to work without reading the save files. This avoids various crashes and hangs, and also ensures that one bad save won't disable the mod on the load screen.
* updates to the latest version of the mod build config package, which simplifies the deploy configuration.